### PR TITLE
Fix issue using str for dataset creation

### DIFF
--- a/bird_cloud_gnn/radar_dataset.py
+++ b/bird_cloud_gnn/radar_dataset.py
@@ -124,8 +124,8 @@ class RadarDataset(DGLDataset):
         self.labels = torch.FloatTensor(self.labels)
 
     def save(self):
-        graph_path = self.data_folder / f"dataset_storage_{self.name}_{self.hash}.bin"
-        info_path = self.data_folder / f"dataset_storage_{self.name}_{self.hash}.pkl"
+        graph_path = os.path.join(self.data_folder, f"dataset_storage_{self.name}_{self.hash}.bin")
+        info_path = os.path.join(self.data_folder, f"dataset_storage_{self.name}_{self.hash}.pkl")
         save_graphs(str(graph_path), self.graphs, {"labels": self.labels})
         save_info(
             str(info_path),
@@ -139,8 +139,8 @@ class RadarDataset(DGLDataset):
         )
 
     def load(self):
-        graph_path = self.data_folder / f"dataset_storage_{self.name}_{self.hash}.bin"
-        info_path = self.data_folder / f"dataset_storage_{self.name}_{self.hash}.pkl"
+        graph_path = os.path.join(self.data_folder, f"dataset_storage_{self.name}_{self.hash}.bin")
+        info_path = os.path.join(self.data_folder, f"dataset_storage_{self.name}_{self.hash}.pkl")
         graphs, label_dict = load_graphs(str(graph_path))
         info = load_info(str(info_path))
 
@@ -154,8 +154,8 @@ class RadarDataset(DGLDataset):
         self.min_neighbours = info["min_neighbours"]
 
     def has_cache(self):
-        graph_path = self.data_folder / f"dataset_storage_{self.name}_{self.hash}.bin"
-        info_path = self.data_folder / f"dataset_storage_{self.name}_{self.hash}.pkl"
+        graph_path = os.path.join(self.data_folder, f"dataset_storage_{self.name}_{self.hash}.bin")
+        info_path = os.path.join(self.data_folder, f"dataset_storage_{self.name}_{self.hash}.pkl")
         if os.path.exists(graph_path) and os.path.exists(info_path):
             return True
         return False

--- a/tests/test_radar_dataset.py
+++ b/tests/test_radar_dataset.py
@@ -58,3 +58,12 @@ def test_radar_dataset(tmp_path):
     with pytest.raises(ValueError) as excinfo:
         RadarDataset(tmp_path, features, target, min_neighbours=10**8)
     assert "No graphs" in str(excinfo.value)
+
+    # Test with a explicit string as argument for folder.
+    dataset = RadarDataset(
+        str(tmp_path),
+        features,
+        target,
+        max_distance=max_distance,
+        min_neighbours=min_neighbours,
+    )


### PR DESCRIPTION
**Description**

<!-- Describe the PR here. -->
When a str was passed to RadarDataset, it would fail because it was expecting a `pathlib.Path`.
All tests used the fixture `tmp_path`, so this was unnoticed.
This PR adds a test and fixes the issue.

**Related issues**:

- #47 

**Instructions to review the pull request**

<!-- One of these should make sense. Uncomment as needed -->
The CI tests are enough

<!--
Clone and run locally with the following:

```
cd $(mktemp -d --tmpdir bird-XXXXXX)
git clone https://github.com/<you>/bird-cloud-gnn .
git checkout <this branch>
python -m venv env
source env/bin/activate
python -m pip install --upgrade pip setuptools
python -m pip install '.[dev]'
<testing commands>
```
-->

<!--
There is no code change, just review the text.
-->
