### PR TITLE
Ignore django not configured in pylint

### DIFF
--- a/.prospector.yml
+++ b/.prospector.yml
@@ -30,5 +30,6 @@ pydocstyle:
 
 pylint:
     disable: [
-        too-many-locals
+        too-many-locals,
+        django-not-configured,
     ]


### PR DESCRIPTION
**Description**

<!-- Describe the PR here. -->
Stop prospector complaining about django not configured by modifying .prospector.yaml

**Related issues**:

No issue was created 

**Instructions to review the pull request**

<!-- One of these should make sense. Uncomment as needed -->
<!--
The CI tests are enough
-->

<!--
Clone and run locally with the following:

```
cd $(mktemp -d --tmpdir bird-XXXXXX)
git clone https://github.com/<you>/bird-cloud-gnn .
git checkout <this branch>
python -m venv env
source env/bin/activate
python -m pip install --upgrade pip setuptools
python -m pip install '.[dev]'
<testing commands>
```
-->

There is no code change, just review the text.
