### PR TITLE
Add prospector and isort to pre-commit.ci skip, since they are being run already

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,5 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
+ci:
+  skip: [prospector, isort]


### PR DESCRIPTION
**Description**

<!-- Describe the PR here. -->
Add prospector and isort to pre-commit.ci skip, since they are being run already

**Related issues**:

- #54 

**Instructions to review the pull request**

<!-- One of these should make sense. Uncomment as needed -->
The CI tests are enough

<!--
Clone and run locally with the following:

```
cd $(mktemp -d --tmpdir bird-XXXXXX)
git clone https://github.com/<you>/bird-cloud-gnn .
git checkout <this branch>
python -m venv env
source env/bin/activate
python -m pip install --upgrade pip setuptools
python -m pip install '.[dev]'
<testing commands>
```
-->

<!--
There is no code change, just review the text.
-->
