### PR TITLE
Fix indexing of points of interest in RadarDataset

### DIFF
--- a/tests/test_radar_dataset.py
+++ b/tests/test_radar_dataset.py
@@ -3,6 +3,7 @@
 import gzip
 import os
 import shutil
+import numpy as np
 import pytest
 from bird_cloud_gnn.fake import generate_data
 from bird_cloud_gnn.radar_dataset import RadarDataset
@@ -107,3 +108,104 @@ def test_radar_dataset(tmp_path):
     assert len(dataset) > 0
     for graph, label in dataset:
         assert graph.num_edges() == min_neighbours**2
+
+
+def test_manually_defined_file(tmp_path):
+    # The data 'two_clusters_one_nan_one_labeled' contains a cluster around 0,
+    # with all of the points unlabeled, and a cluster around (5,5,5), with
+    # all of the points labeled. The points are (5,5,5), (6,5,5), (5,6,5),
+    # and (5,5,6). The labels are 0 for (5,5,5) and 1 for the others.
+    # There is a single feature, f1, whose value is equal to index+1.
+
+    with open(
+        tmp_path / "two_clusters_one_nan_one_labeled.csv", "w", encoding="utf-8"
+    ) as f:
+        f.write(
+            """range,x,y,z,f1,target
+10000,0,0,0,1,
+10000,1,0,0,2,
+10000,0,1,0,3,
+10000,0,0,1,4,
+10000,5,5,5,5,0
+10000,6,5,5,6,1
+10000,5,6,5,7,1
+10000,5,5,6,8,1"""
+        )
+
+    # Distance is small enough so there is only one graph
+    dataset = RadarDataset(
+        tmp_path,
+        ["x", "y", "z", "f1"],
+        "target",
+        max_distance=1.1,
+        min_neighbours=4,
+        max_edge_distance=1.0,
+    )
+    assert len(dataset) == 1
+    graph, label = dataset[0]
+    assert label == 0
+    F = np.array(graph.ndata["x"])
+    F = F[F[:, -1].argsort()]
+    assert np.all(
+        F
+        == np.array(
+            [
+                [5, 5, 5, 5],
+                [6, 5, 5, 6],
+                [5, 6, 5, 7],
+                [5, 5, 6, 8],
+            ]
+        )
+    )
+    print(graph)
+    assert graph.num_edges() == 3 * 2 + 4
+
+    # Increase edge radius to make it a complete graph
+    dataset = RadarDataset(
+        tmp_path,
+        ["x", "y", "z", "f1"],
+        "target",
+        max_distance=1.1,
+        min_neighbours=4,
+        max_edge_distance=2.0,
+    )
+    assert len(dataset) == 1
+    graph, label = dataset[0]
+    assert label == 0
+    F = np.array(graph.ndata["x"])
+    F = F[F[:, -1].argsort()]
+    assert np.all(
+        F
+        == np.array(
+            [
+                [5, 5, 5, 5],
+                [6, 5, 5, 6],
+                [5, 6, 5, 7],
+                [5, 5, 6, 8],
+            ]
+        )
+    )
+    print(graph)
+    assert graph.num_edges() == 4 * 4
+
+    # Increase distance so other points in cluster also become graphs
+    dataset = RadarDataset(
+        tmp_path,
+        ["x", "y", "z", "f1"],
+        "target",
+        max_distance=1.42,
+        min_neighbours=4,
+    )
+    assert len(dataset) == 4
+    labels = [d[1] for d in dataset]
+    assert np.all(sorted(np.array(labels)) == np.array([0, 1, 1, 1]))
+
+    # Increase distance but also min_neighbours, so only one graph with all points exist
+    dataset = RadarDataset(
+        tmp_path,
+        ["x", "y", "z", "f1"],
+        "target",
+        max_distance=5 * np.sqrt(3) + 0.01,
+        min_neighbours=8,
+    )
+    assert len(dataset) == 1


### PR DESCRIPTION
**Description**

<!-- Describe the PR here. -->
The graphs were not being correctly created because of indexing related to points of interest.
When selecting the nodes related to the neighbours of the POI, the index should be relative to the "not NA" dataframe, but instead, they were selected from the full dataset. To fix, I keep the relative index of the "not NA" in relation to the full dataset. A refactoring would be useful to figure out a better way to deal with this, but since this code might disappear if the use a DB, I am leaving it for later.
The labels were selected correctly already.

The changes are:
- Fix indexing
- Add tests with a very small file for which we can actually see what is happening.
- Workaround for the number of neighbours (see #80)


**Related issues**:

- #79 

**Instructions to review the pull request**

<!-- One of these should make sense. Uncomment as needed -->

The CI tests are enough.


<!--
Clone and run locally with the following:

```
cd $(mktemp -d --tmpdir bird-XXXXXX)
git clone https://github.com/<you>/bird-cloud-gnn .
git checkout <this branch>
python -m venv env
source env/bin/activate
python -m pip install --upgrade pip setuptools
python -m pip install '.[dev]'
<testing commands>
```
-->

<!--
There is no code change, just review the text.
-->
