### PR TITLE
Speed improvements to RadarDataset

### DIFF
--- a/bird_cloud_gnn/radar_dataset.py
+++ b/bird_cloud_gnn/radar_dataset.py
@@ -58,7 +58,7 @@ class RadarDataset(DGLDataset):
             ValueError: If `data_folder` is not a valid folder.
         """
         if not os.path.isdir(data_folder):
-            raise ValueError(f"'${data_folder}' is not a folder")
+            raise ValueError(f"'{data_folder}' is not a folder")
         self._name = name
         self.data_folder = data_folder
         self.features = features

--- a/bird_cloud_gnn/radar_dataset.py
+++ b/bird_cloud_gnn/radar_dataset.py
@@ -86,9 +86,15 @@ class RadarDataset(DGLDataset):
 
         xyz = ["x", "y", "z"]
         split_on_dots = data_file.split(".")
-        if split_on_dots[-1] != "csv" and ".".join(split_on_dots[-2:]) != "csv.gz":
+        if (
+            split_on_dots[-1] not in ["csv", "parquet"]
+            and ".".join(split_on_dots[-2:]) != "csv.gz"
+        ):
             return
-        data = pd.read_csv(os.path.join(self.data_folder, data_file))
+        if split_on_dots[-1] == "parquet":
+            data = pd.read_parquet(os.path.join(self.data_folder, data_file))
+        else:
+            data = pd.read_csv(os.path.join(self.data_folder, data_file))
         data = data.drop(
             data[
                 np.logical_or(

--- a/bird_cloud_gnn/radar_dataset.py
+++ b/bird_cloud_gnn/radar_dataset.py
@@ -109,10 +109,11 @@ class RadarDataset(DGLDataset):
         data_notna.reset_index(drop=True, inplace=True)
         tree = KDTree(data.loc[:, xyz])
         tree_notna = KDTree(data_notna.loc[:, xyz])
-        distance_matrix = tree_notna.sparse_distance_matrix(tree, self.max_distance)
-        number_neighbours = (
-            np.array(np.sum(distance_matrix > 0, axis=1)).reshape(-1) + 1
+        distance_matrix = tree_notna.sparse_distance_matrix(
+            tree, self.max_distance, output_type="coo_matrix"
         )
+
+        number_neighbours = distance_matrix.getnnz(1)
         points_of_interest = np.where(number_neighbours >= self.min_neighbours)[0]
 
         for point in points_of_interest:


### PR DESCRIPTION
**Description**

<!-- Describe the PR here. -->
Many improvements to RadarDataset.

**Related issues**:


**Instructions to review the pull request**

The following script ran on 271.5 seconds on SURF Research Cloud:

```bash
import time

from bird_cloud_gnn.radar_dataset import RadarDataset

st = time.perf_counter()
try:
    dataset = RadarDataset(
        "data/parquet",
        ["x", "y", "z"],
        "BIOLOGY",
        min_neighbours=25,
        max_distance=500.0,
        max_edge_distance=250.1,
    )
    print(dataset)
    print(dataset[0])
    print(dataset[0][0])
except ValueError as ex:
    print("Error:", ex)
print("Total time:", time.perf_counter() - st)
```

`data/parquet` contains all data converted to parquet files (114 files). The results:

```plaintext
Dataset("Radar", num_graphs=383288, save_path=/home/asoaressiq/.dgl/Radar)
(Graph(num_nodes=25, num_edges=487,
      ndata_schemes={'x': Scheme(shape=(3,), dtype=torch.float64)}
      edata_schemes={'a': Scheme(shape=(), dtype=torch.float64)}), tensor(0))
Graph(num_nodes=25, num_edges=487,
      ndata_schemes={'x': Scheme(shape=(3,), dtype=torch.float64)}
      edata_schemes={'a': Scheme(shape=(), dtype=torch.float64)})
Total time: 271.5795489749871
```