### PR TITLE
Add origin and max_edge_distance to RadarDataset cache

### DIFF
--- a/bird_cloud_gnn/radar_dataset.py
+++ b/bird_cloud_gnn/radar_dataset.py
@@ -85,9 +85,9 @@ class RadarDataset(DGLDataset):
                 data_hash,
                 features,
                 target,
-                num_neighbours,
                 max_edge_distance,
                 max_poi_per_label,
+                num_neighbours,
             ),
         )
 
@@ -219,9 +219,11 @@ class RadarDataset(DGLDataset):
             {
                 "data_path": self.data_path,
                 "features": self.features,
-                "target": self.target,
-                "num_neighbours": self.num_neighbours,
+                "max_edge_distance": self.max_edge_distance,
                 "max_poi_per_label": self.max_poi_per_label,
+                "num_neighbours": self.num_neighbours,
+                "origin": self.origin,
+                "target": self.target,
             },
         )
 
@@ -240,9 +242,11 @@ class RadarDataset(DGLDataset):
 
         self.data_path = info["data_path"]
         self.features = info["features"]
-        self.target = info["target"]
-        self.num_neighbours = info["num_neighbours"]
+        self.max_edge_distance = info["max_edge_distance"]
         self.max_poi_per_label = info["max_poi_per_label"]
+        self.num_neighbours = info["num_neighbours"]
+        self.origin = info["origin"]
+        self.target = info["target"]
 
     def cache_dir(self):
         if self.data_path is None:

--- a/tests/test_radar_dataset.py
+++ b/tests/test_radar_dataset.py
@@ -66,6 +66,7 @@ def test_radar_dataset(tmp_path):
         num_neighbours=num_neighbours,
         max_edge_distance=max_edge_distance,
     )
+    assert len(dataset.origin) == len(dataset)
 
     # Test with a explicit string as argument for folder.
     dataset = RadarDataset(


### PR DESCRIPTION
**Description**

Add origin and max_edge_distance to cache.
Order alphabetically.

**Related issues**:

Closes #97 

**Instructions to review the pull request**

<!-- One of these should make sense. Uncomment as needed -->
<!--
The CI tests are enough
-->

<!--
Clone and run locally with the following:

```
cd $(mktemp -d --tmpdir bird-XXXXXX)
git clone https://github.com/<you>/bird-cloud-gnn .
git checkout <this branch>
python -m venv env
source env/bin/activate
python -m pip install --upgrade pip setuptools
python -m pip install '.[dev]'
<testing commands>
```
-->

<!--
There is no code change, just review the text.
-->
