### PR TITLE
Don't use the tree when num_nodes equals 1

### DIFF
--- a/tests/test_radar_dataset.py
+++ b/tests/test_radar_dataset.py
@@ -323,3 +323,32 @@ def test_not_enough_points_in_neighbourhood(tmp_path):
         max_poi_per_label=10,
     )
     assert len(dataset) == 0
+
+
+def test_num_nodes_equal_to_1(tmp_path):
+    with open(
+        tmp_path / "two_clusters_one_nan_one_labeled.csv", "w", encoding="utf-8"
+    ) as f:
+        f.write(
+            """range,x,y,z,f1,target
+10000,1,1,1,1,
+10000,0,1,1,2,
+10000,1,0,1,3,
+10000,1,1,0,4,
+10000,5,5,5,5,0
+10000,6,5,5,6,1
+10000,5,6,5,7,1
+10000,5,5,6,8,1"""
+        )
+
+    dataset = RadarDataset(
+        tmp_path,
+        ["x", "y", "z", "f1"],
+        "target",
+        num_nodes=1,
+        max_edge_distance=2.0,
+        max_poi_per_label=10,
+    )
+    assert len(dataset) == 4
+    for graph, _ in dataset:
+        assert graph.num_nodes() == 1


### PR DESCRIPTION
**Description**

Workaround for when the num_nodes is equal to 1.
Use explicit computation of graph and distances: since there is only one node, it is trivial.

**Related issues**:

Closes #120 

**Instructions to review the pull request**

<!-- One of these should make sense. Uncomment as needed -->
<!--
The CI tests are enough
-->

<!--
Clone and run locally with the following:

```
cd $(mktemp -d --tmpdir bird-XXXXXX)
git clone https://github.com/<you>/bird-cloud-gnn .
git checkout <this branch>
python -m venv env
source env/bin/activate
python -m pip install --upgrade pip setuptools
python -m pip install '.[dev]'
<testing commands>
```
-->

<!--
There is no code change, just review the text.
-->
