### PR TITLE
Add oneline_description for model and dataset

### DIFF
--- a/bird_cloud_gnn/gnn_model.py
+++ b/bird_cloud_gnn/gnn_model.py
@@ -43,6 +43,18 @@ class GCN(nn.Module):
         self.conv1 = GraphConv(in_feats, h_feats)
         self.conv2 = GraphConv(h_feats, num_classes)
 
+    def oneline_description(self):
+        """Description of the model to uniquely identify it in logs"""
+        return "-".join(
+            [
+                "in",
+                f"GC_{self.h_feats}",
+                "RELU",
+                f"GC_{self.num_classes}",
+                "mean-out",
+            ]
+        )
+
     def forward(self, g, in_feat):
         """
         The forward function computes the output of the model.

--- a/bird_cloud_gnn/radar_dataset.py
+++ b/bird_cloud_gnn/radar_dataset.py
@@ -123,6 +123,23 @@ class RadarDataset(DGLDataset):
             ),
         )
 
+    def oneline_description(self):
+        """Description of the dataset to uniquely identify it in logs"""
+        return (
+            "-".join(
+                [
+                    self.hash,
+                    f"MED_{self.max_edge_distance}",
+                    f"NN_{self.num_nodes}",
+                    f"MPPL_{self.max_poi_per_label}",
+                    f"UMIC_{self.use_missing_indicator_columns}",
+                    f"AETP_{self.add_edges_to_poi}",
+                ]
+            )
+            + "-features_"
+            + "-".join(self.features)
+        )
+
     def _read_one_file(self, data_path):
         """Reads a file and creates the graphs and labels for it."""
         split_on_dots = data_path.split(".")


### PR DESCRIPTION
**Description**

Implements method `oneline_description` for model and dataset.

**Related issues**:

- #127 

**Instructions to review the pull request**

<!-- One of these should make sense. Uncomment as needed -->
<!--
The CI tests are enough
-->

<!--
Clone and run locally with the following:

```
cd $(mktemp -d --tmpdir bird-XXXXXX)
git clone https://github.com/<you>/bird-cloud-gnn .
git checkout <this branch>
python -m venv env
source env/bin/activate
python -m pip install --upgrade pip setuptools
python -m pip install '.[dev]'
<testing commands>
```
-->

<!--
There is no code change, just review the text.
-->
